### PR TITLE
Core jobs refactor: JobRegistry/Queue, mining MVP, FOV resource, path cache

### DIFF
--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -97,7 +97,8 @@ fn build_world(args: &Args) -> World {
     world.insert_resource(map);
 
     // Resources
-    world.insert_resource(JobBoard::default());
+    world.insert_resource(jobs::JobRegistry::default());
+    world.insert_resource(jobs::JobQueue::default());
     world.insert_resource(designations::DesignationConfig { auto_jobs: true });
 
     // A test goblin
@@ -106,6 +107,14 @@ fn build_world(args: &Args) -> World {
         Position(1, 1),
         Velocity(1, 0),
         Carrier,
+        AssignedJob::default(),
+        VisionRadius(8),
+    ));
+    // A miner for job execution demos
+    world.spawn((
+        Name("Krug".into()),
+        Position(6, 5),
+        Miner,
         AssignedJob::default(),
         VisionRadius(8),
     ));
@@ -118,8 +127,9 @@ fn build_default_schedule() -> Schedule {
     schedule.add_systems((
         systems::movement,
         systems::confine_to_map,
-        jobs::job_assignment_system,
         designations::designation_to_jobs_system,
+        jobs::miner_assignment_system,
+        jobs::mining_execution_system,
     ));
     schedule
 }

--- a/crates/gc_core/src/components.rs
+++ b/crates/gc_core/src/components.rs
@@ -4,9 +4,6 @@ use bevy_ecs::prelude::*;
 pub struct Goblin;
 
 #[derive(Component, Debug)]
-pub struct JobQueue;
-
-#[derive(Component, Debug)]
 pub struct Carrier;
 
 #[derive(Component, Debug)]

--- a/crates/gc_core/src/designations.rs
+++ b/crates/gc_core/src/designations.rs
@@ -1,5 +1,6 @@
 use bevy_ecs::prelude::*;
-use crate::jobs::{JobKind, add_job, JobBoard};
+use crate::jobs::{JobKind, add_job, JobQueue, JobRegistry};
+use std::collections::HashSet;
 
 #[derive(Component, Debug)]
 pub struct MineDesignation;
@@ -15,11 +16,17 @@ pub struct DesignationConfig { pub auto_jobs: bool }
 
 pub fn designation_to_jobs_system(
     config: Res<DesignationConfig>,
-    mut board: ResMut<JobBoard>,
-    q: Query<&crate::world::Position, With<MineDesignation>>,
+    mut queue: ResMut<JobQueue>,
+    mut reg: ResMut<JobRegistry>,
+    mut commands: Commands,
+    q: Query<(Entity, &crate::world::Position), With<MineDesignation>>,
 ) {
     if !config.auto_jobs { return; }
-    for pos in q.iter() {
-        add_job(&mut board, JobKind::Mine { x: pos.0, y: pos.1 });
+    let mut seen: HashSet<(i32,i32)> = HashSet::new();
+    for (e, pos) in q.iter() {
+        if !seen.insert((pos.0, pos.1)) { continue; }
+        add_job(&mut queue, &mut reg, JobKind::Mine { x: pos.0, y: pos.1 });
+        // Consume designation entity after creating job
+        commands.entity(e).despawn();
     }
 }

--- a/crates/gc_core/src/jobs.rs
+++ b/crates/gc_core/src/jobs.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::prelude::*;
 use uuid::Uuid;
 use crate::components::AssignedJob;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct JobId(pub Uuid);
@@ -18,26 +19,64 @@ pub struct Job {
 }
 
 #[derive(Resource, Default, Debug)]
-pub struct JobBoard(pub Vec<Job>);
+pub struct JobRegistry(pub HashMap<JobId, Job>);
 
-pub fn add_job(board: &mut ResMut<JobBoard>, kind: JobKind) -> JobId {
+#[derive(Resource, Default, Debug)]
+pub struct JobQueue(pub Vec<JobId>);
+
+pub fn add_job(queue: &mut ResMut<JobQueue>, reg: &mut ResMut<JobRegistry>, kind: JobKind) -> JobId {
     let id = JobId(Uuid::new_v4());
-    board.0.push(Job { id, kind });
+    reg.0.insert(id, Job { id, kind });
+    queue.0.push(id);
     id
 }
 
-pub fn take_next_job(board: &mut ResMut<JobBoard>) -> Option<Job> { board.0.pop() }
+pub fn take_next_matching<F>(queue: &mut ResMut<JobQueue>, reg: &Res<JobRegistry>, pred: F) -> Option<JobId>
+where F: Fn(&Job) -> bool {
+    if queue.0.is_empty() { return None; }
+    let mut idx = None;
+    for (i, jid) in queue.0.iter().enumerate() {
+        if let Some(job) = reg.0.get(jid) { if pred(job) { idx = Some(i); break; } }
+    }
+    if let Some(i) = idx { Some(queue.0.remove(i)) } else { None }
+}
 
-pub fn job_assignment_system(
-    mut board: ResMut<JobBoard>,
-    mut q_idle: Query<&mut AssignedJob, (With<crate::components::Carrier>, Without<crate::components::Miner>)>,
+pub fn get_job<'a>(reg: &'a Res<JobRegistry>, id: JobId) -> Option<&'a Job> { reg.0.get(&id) }
+pub fn remove_job(reg: &mut ResMut<JobRegistry>, id: JobId) { reg.0.remove(&id); }
+
+pub fn miner_assignment_system(
+    mut queue: ResMut<JobQueue>,
+    reg: Res<JobRegistry>,
+    mut q_idle: Query<&mut AssignedJob, With<crate::components::Miner>>,
 ) {
     for mut assigned in q_idle.iter_mut() {
         if assigned.0.is_none() {
-            if let Some(job) = take_next_job(&mut board) {
-                assigned.0 = Some(job.id);
-                // For MVP we just drop the job; execution systems would track active jobs.
+            if let Some(id) = take_next_matching(&mut queue, &reg, |j| matches!(j.kind, JobKind::Mine { .. })) {
+                assigned.0 = Some(id);
             }
+        }
+    }
+}
+
+pub fn mining_execution_system(
+    mut map: ResMut<crate::world::GameMap>,
+    mut reg: ResMut<JobRegistry>,
+    mut q: Query<(&crate::world::Position, &mut AssignedJob), With<crate::components::Miner>>,
+) {
+    for (_pos, mut assigned) in q.iter_mut() {
+        let Some(job_id) = assigned.0 else { continue };
+        let Some(job) = reg.0.get(&job_id).cloned() else { continue };
+        match job.kind {
+            JobKind::Mine { x, y } => {
+                if let Some(kind) = map.get_tile(x, y) {
+                    if matches!(kind, crate::world::TileKind::Wall) {
+                        let _ = map.set_tile(x, y, crate::world::TileKind::Floor);
+                    }
+                }
+                assigned.0 = None;
+                reg.0.remove(&job_id);
+            }
+            _ => {}
         }
     }
 }

--- a/crates/gc_core/src/lib.rs
+++ b/crates/gc_core/src/lib.rs
@@ -6,7 +6,7 @@
 
 pub mod prelude {
     pub use crate::world::*;
-    pub use crate::components::*;
+    pub use crate::components::{Goblin, Carrier, Miner, AssignedJob, VisionRadius};
     pub use crate::systems::*;
     pub use crate::jobs::*;
     pub use crate::mapgen::*;

--- a/docs/design/ai_jobs.md
+++ b/docs/design/ai_jobs.md
@@ -1,10 +1,17 @@
 # AI Jobs and Designations
 
-We maintain a `JobBoard` resource with simple FIFO/LIFO scheduling in M0. Agents with the `Carrier` role can be assigned jobs by `job_assignment_system`.
+We maintain a `JobRegistry` (map of `JobId -> Job`) and a `JobQueue` (pending jobs by id). Agents pull jobs that match their role.
 
 ## Designations -> Jobs
 
-`MineDesignation` entities with a `Position` are converted into `JobKind::Mine` when `DesignationConfig.auto_jobs` is enabled. The system `designation_to_jobs_system` performs this mapping each tick. Future work: remove the designation after job creation, avoid duplicate job creation, and support areas/selections.
+`MineDesignation` entities with a `Position` are converted into `JobKind::Mine` when `DesignationConfig.auto_jobs` is enabled. After creating a job, the designation entity is despawned. A simple in-tick dedupe prevents duplicate jobs from multiple identical designations.
+
+## Assignment and Execution
+
+- `miner_assignment_system`: assigns the next matching `Mine` job id to idle `Miner` agents.
+- `mining_execution_system`: when a miner has a `Mine{x,y}` job, it instantly converts a `Wall` at `(x,y)` into `Floor` (MVP behavior), then clears the assignment and removes the job from the registry.
+
+Future work: path-based approach to reach targets, tool requirements, multi-tile designations, and ownership/priorities.
 
 ## Next steps
 


### PR DESCRIPTION
This PR introduces:

- JobRegistry and JobQueue primitives
- Role-aware job assignment and Miner entity
- Mining execution MVP and designation lifecycle (consume entity, dedupe)
- Per-entity FOV/visibility resource and compute system
- Batched pathfinding service with LRU cache and CLI demo
- CLI harness updates and schedule wiring
- New and updated unit tests
- Documentation updates (architecture overview, roadmap, sim loop, jobs, pathfinding, save/load)

All code builds and tests pass locally. Ready for review.
