### PR TITLE
[M1] Impl: Time resource + fixed-tick schedule + ordering notes

### DIFF
--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -99,6 +99,8 @@ fn build_world(args: &Args) -> World {
     // Resources
     world.insert_resource(JobBoard::default());
     world.insert_resource(designations::DesignationConfig { auto_jobs: true });
+    // Deterministic fixed-step time resource (10 Hz reference)
+    world.insert_resource(systems::Time::new(100));
 
     // A test goblin
     world.spawn((
@@ -124,6 +126,7 @@ fn build_default_schedule() -> Schedule {
         )
             .chain(),
         jobs::job_assignment_system,
+        systems::advance_time,
     ));
     schedule
 }

--- a/crates/gc_core/src/systems.rs
+++ b/crates/gc_core/src/systems.rs
@@ -1,6 +1,22 @@
 use crate::world::*;
 use bevy_ecs::prelude::*;
 
+/// Fixed-step time resource for deterministic ticks
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct Time {
+    /// Accumulated tick count
+    pub ticks: u64,
+    /// Duration of a tick in milliseconds (for reference/logging)
+    pub tick_ms: u64,
+}
+
+impl Time {
+    pub fn new(tick_ms: u64) -> Self {
+        Self { ticks: 0, tick_ms }
+    }
+}
+
+/// Movement system (runs early)
 pub fn movement(mut q: Query<(&mut Position, &Velocity)>) {
     for (mut pos, vel) in q.iter_mut() {
         pos.0 += vel.0;
@@ -8,9 +24,15 @@ pub fn movement(mut q: Query<(&mut Position, &Velocity)>) {
     }
 }
 
+/// Confine positions to map bounds (runs after movement)
 pub fn confine_to_map(map: Res<GameMap>, mut q: Query<&mut Position>) {
     for mut pos in q.iter_mut() {
         pos.0 = pos.0.clamp(0, map.width as i32 - 1);
         pos.1 = pos.1.clamp(0, map.height as i32 - 1);
     }
+}
+
+/// Increments the tick counter; place at the end of the schedule for clarity
+pub fn advance_time(mut time: ResMut<Time>) {
+    time.ticks = time.ticks.saturating_add(1);
 }

--- a/crates/gc_core/src/systems.rs
+++ b/crates/gc_core/src/systems.rs
@@ -34,5 +34,5 @@ pub fn confine_to_map(map: Res<GameMap>, mut q: Query<&mut Position>) {
 
 /// Increments the tick counter; place at the end of the schedule for clarity
 pub fn advance_time(mut time: ResMut<Time>) {
-    time.ticks = time.ticks.saturating_add(1);
+    time.ticks += 1;
 }

--- a/docs/design/sim_loop.md
+++ b/docs/design/sim_loop.md
@@ -16,9 +16,11 @@ Tick order is designed to be deterministic. Current default schedule:
 3. Designation -> Job mapping (if enabled)
 4. Job assignment
 5. Visibility recomputation
+6. Advance Time (ticks++)
 
 Notes:
 
 - Visibility uses per-entity computation with Bresenham LOS within a radius.
 - Pathfinding requests should be funneled through `PathService` for caching.
 - Future: system ordering will move to explicit sets and stages.
+- Time: A fixed-step `Time` resource (`systems::Time`) increments once per schedule run to aid deterministic replay and logging.


### PR DESCRIPTION
Implements issue #14: Introduce a deterministic Time resource and fixed-tick schedule wiring.\n\n- gc_core::systems::Time { ticks, tick_ms } + advance_time system\n- CLI inserts Time (100ms/tick) and adds advance_time at end of default schedule\n- Docs updated: sim_loop now lists Advance Time and notes Time resource\n\nBuild/lint/tests: ./dev.sh check PASS.