### PR TITLE
[M3] TUI shell design + prototype\n\n- Add new crate gc_tui with ratatui + crossterm loop (pause/step/vis/SPF)\n- Wire  subcommand into gc_cli\n- Workspace update and docs: design/tui_shell.md, link from docs index\n\nRefs: #27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,10 +246,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cfg-if"
@@ -331,12 +346,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -351,7 +389,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -372,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -401,10 +439,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.0.8",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "deprecate-until"
@@ -416,6 +532,36 @@ dependencies = [
  "quote",
  "semver",
  "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -447,6 +593,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +619,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -503,6 +665,7 @@ dependencies = [
  "bevy_ecs",
  "clap",
  "gc_core",
+ "gc_tui",
  "rand",
  "serde",
  "serde_json",
@@ -522,6 +685,19 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "uuid",
+]
+
+[[package]]
+name = "gc_tui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bevy_ecs",
+ "crossterm 0.29.0",
+ "gc_core",
+ "rand",
+ "ratatui",
+ "serde",
 ]
 
 [[package]]
@@ -594,6 +770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +783,25 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "instability"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -639,6 +840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +871,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +918,18 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "noise"
@@ -730,6 +980,35 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathfinding"
@@ -862,6 +1141,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +1179,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -917,6 +1226,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +1271,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -976,6 +1317,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,10 +1359,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1110,6 +1509,35 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"
@@ -1252,6 +1680,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1703,12 @@ checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
     "crates/gc_core",
     "crates/gc_cli",
+    "crates/gc_tui",
 ]
 resolver = "2"

--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -11,6 +11,8 @@ use std::io::{self, Write};
 enum Demo {
     /// Interactive menu
     Menu,
+    /// Interactive TUI prototype (ratatui + crossterm)
+    Tui,
     /// Show generated map and basic info
     Mapgen,
     /// Line-of-sight/FOV demo
@@ -405,7 +407,8 @@ fn interactive_pick() -> Demo {
     println!("4) Jobs & Designations");
     println!("5) Save/Load");
     println!("6) Path Batch + Cache");
-    print!("Select [1-6]: ");
+    println!("7) TUI Prototype");
+    print!("Select [1-7]: ");
     let _ = io::stdout().flush();
 
     let mut buf = String::new();
@@ -417,6 +420,7 @@ fn interactive_pick() -> Demo {
             "4" => Demo::Jobs,
             "5" => Demo::SaveLoad,
             "6" => Demo::PathBatch,
+            "7" => Demo::Tui,
             _ => Demo::Mapgen,
         }
     } else {
@@ -439,6 +443,10 @@ fn main() -> Result<()> {
         Demo::Jobs => run_demo_jobs(&args),
         Demo::SaveLoad => run_demo_save(&args),
         Demo::PathBatch => run_demo_path_batch(&args),
+        Demo::Tui => {
+            gc_tui::run(args.width, args.height, args.seed)?;
+            Ok(())
+        }
         Demo::Menu => Ok(()),
     }
 }

--- a/crates/gc_tui/Cargo.toml
+++ b/crates/gc_tui/Cargo.toml
@@ -1,22 +1,18 @@
 [package]
-name = "gc_cli"
+name = "gc_tui"
 version = "0.1.0"
 edition = "2021"
-description = "CLI shell for Goblin Camp to run headless simulations or text UI"
+description = "Terminal UI for Goblin Camp using ratatui + crossterm"
 license = "MIT OR Apache-2.0"
 authors = ["Goblin Camp Contributors"]
 
 [dependencies]
+anyhow = "1.0"
+ratatui = { version = "0.29", default-features = true, features = ["crossterm"] }
+crossterm = "0.29"
 bevy_ecs = "0.14"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-clap = { version = "4.5", features = ["derive"] }
-anyhow = "1.0"
 rand = "0.8"
 
-# Workspace members
 [dependencies.gc_core]
 path = "../gc_core"
-
-[dependencies.gc_tui]
-path = "../gc_tui"

--- a/crates/gc_tui/src/lib.rs
+++ b/crates/gc_tui/src/lib.rs
@@ -1,0 +1,237 @@
+use anyhow::Result;
+use bevy_ecs::prelude::*;
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use gc_core::prelude::*;
+use gc_core::{designations, jobs, systems};
+use rand::Rng;
+use ratatui::{
+    layout::{Constraint, Layout},
+    style::{Color, Style},
+    text::Span,
+    widgets::{Block, Borders, Paragraph},
+    Frame,
+};
+
+/// Basic app state for the TUI
+#[derive(Default)]
+pub struct AppState {
+    pub paused: bool,
+    pub show_vis: bool,
+    pub steps_per_frame: u32,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            paused: false,
+            show_vis: false,
+            steps_per_frame: 1,
+        }
+    }
+}
+
+/// Build a default world similar to CLI demos
+pub fn build_world(width: u32, height: u32, seed: u64) -> World {
+    let mut world = World::new();
+    world.insert_resource(systems::DeterministicRng::new(seed));
+
+    // Mapgen with deterministic RNG stream
+    let gen = MapGenerator::new();
+    let mapgen_seed = {
+        let mut rng = world.resource_mut::<systems::DeterministicRng>();
+        rng.mapgen_rng.gen::<u32>()
+    };
+    let map = gen.generate(width, height, mapgen_seed);
+    world.insert_resource(map);
+
+    // Core resources
+    world.insert_resource(JobBoard::default());
+    world.insert_resource(jobs::ItemSpawnQueue::default());
+    world.insert_resource(jobs::ActiveJobs::default());
+    world.insert_resource(designations::DesignationConfig { auto_jobs: true });
+    world.insert_resource(systems::Time::new(100)); // 10 ms per tick (100 Hz logical tick)
+
+    // Example agents
+    world.spawn((
+        Name("Grak".into()),
+        Position(5, 5),
+        Velocity(0, 0),
+        Miner,
+        AssignedJob::default(),
+        VisionRadius(8),
+    ));
+    world.spawn((
+        Name("Urok".into()),
+        Position(5, 5),
+        Velocity(0, 0),
+        Carrier,
+        Inventory::default(),
+        AssignedJob::default(),
+        VisionRadius(8),
+    ));
+
+    // Example stockpile
+    world
+        .spawn(gc_core::stockpiles::StockpileBundle::new(9, 9, 11, 11))
+        .insert(Name("Stockpile".into()));
+
+    world
+}
+
+pub fn build_schedule() -> Schedule {
+    let mut schedule = Schedule::default();
+    schedule.add_systems((
+        systems::movement,
+        systems::confine_to_map,
+        (
+            designations::designation_dedup_system,
+            designations::designation_to_jobs_system,
+            jobs::job_assignment_system,
+        )
+            .chain(),
+        (
+            jobs::mine_job_execution_system,
+            systems::hauling_execution_system,
+            systems::auto_haul_system,
+        ),
+        systems::advance_time,
+    ));
+    schedule
+}
+
+/// One frame of simulation if not paused
+fn step_sim(world: &mut World, schedule: &mut Schedule, app: &AppState) {
+    if app.paused {
+        return;
+    }
+    for _ in 0..app.steps_per_frame {
+        schedule.run(world);
+    }
+}
+
+/// Draw the map and overlays
+fn draw(frame: &mut Frame, world: &World, app: &AppState) {
+    let areas = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(frame.area());
+
+    // Title
+    frame.render_widget(
+        Block::default()
+            .title("Goblin Camp — TUI Prototype")
+            .borders(Borders::BOTTOM),
+        areas[0],
+    );
+
+    // Main map area: render a simple ASCII map using Paragraph buffer for now
+    let map = world.resource::<GameMap>();
+    let mut lines = Vec::with_capacity(map.height as usize);
+
+    // Optional visibility overlay: compute union of visible tiles into a set if enabled
+    let mut visible: Option<std::collections::HashSet<(i32, i32)>> = None;
+    if app.show_vis {
+        if world.contains_resource::<gc_core::fov::Visibility>() {
+            let vis = world.resource::<gc_core::fov::Visibility>();
+            let mut set = std::collections::HashSet::new();
+            for tiles in vis.per_entity.values() {
+                set.extend(tiles.iter().copied());
+            }
+            visible = Some(set);
+        }
+    }
+
+    for y in 0..map.height as i32 {
+        let mut row = String::with_capacity(map.width as usize);
+        for x in 0..map.width as i32 {
+            let mut ch = match map.get_tile(x, y).unwrap_or(TileKind::Wall) {
+                TileKind::Floor => '.',
+                TileKind::Wall => '#',
+                TileKind::Water => '~',
+                TileKind::Lava => '^',
+            };
+
+            if let Some(v) = &visible {
+                if v.contains(&(x, y)) {
+                    ch = '*';
+                }
+            }
+            row.push(ch);
+        }
+        lines.push(row);
+    }
+
+    let text = lines.join("\n");
+    let para = Paragraph::new(text).style(Style::default().fg(Color::White));
+    frame.render_widget(para, areas[1]);
+
+    // Status bar
+    let status = format!(
+        "[q] quit  [space] {}  [.] step  [v] vis={}  [1-9] spf={}",
+        if app.paused { "resume" } else { "pause" },
+        app.show_vis,
+        app.steps_per_frame
+    );
+    frame.render_widget(
+        Paragraph::new(Span::raw(status)).block(Block::default().borders(Borders::TOP)),
+        areas[2],
+    );
+}
+
+/// Run the interactive TUI loop. Returns when the user quits.
+pub fn run(width: u32, height: u32, seed: u64) -> Result<()> {
+    // Build world and schedule
+    let mut world = build_world(width, height, seed);
+    world.insert_resource(gc_core::fov::Visibility::default());
+    let mut schedule = build_schedule();
+
+    // Initialize terminal
+    let mut terminal = ratatui::init();
+
+    let mut app = AppState::new();
+
+    // Main loop
+    loop {
+        // Draw
+        terminal.draw(|f| draw(f, &world, &app))?;
+
+        // Handle input (non-blocking small poll)
+        if event::poll(std::time::Duration::from_millis(16))? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => break,
+                    KeyCode::Char(' ') => app.paused = !app.paused,
+                    KeyCode::Char('.') => {
+                        let once = AppState {
+                            steps_per_frame: 1,
+                            ..app
+                        };
+                        step_sim(&mut world, &mut schedule, &once);
+                    }
+                    KeyCode::Char('v') => app.show_vis = !app.show_vis,
+                    KeyCode::Char(d) if d.is_ascii_digit() && d != '0' => {
+                        app.steps_per_frame = d.to_digit(10).unwrap_or(1);
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        // Step sim
+        step_sim(&mut world, &mut schedule, &app);
+
+        // Recompute visibility each frame if overlay is enabled
+        if app.show_vis {
+            let mut fov_sched = Schedule::default();
+            fov_sched.add_systems((gc_core::fov::compute_visibility_system,));
+            fov_sched.run(&mut world);
+        }
+    }
+
+    // Restore terminal
+    ratatui::restore();
+    Ok(())
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,29 +9,34 @@ This directory contains the complete design documentation, architectural decisio
 ## 🚀 Quick Navigation
 
 ### 🎯 **Getting Started**
+
 - **[Main README](../README.md)** - Project overview and quick start guide
 - **[Development Roadmap](plan/MASTER_PLAN.md)** - Long-term vision and development milestones
 - **[Contributing Guide](../README.md#contributing)** - How to contribute to the project
 
 ### 🏗️ **Architecture & Design**
+
 - **[System Overview](architecture/01_overview.md)** - Core architecture and ECS design principles
 - **[Architecture Decisions](architecture/adr/)** - Record of important architectural choices
 - **[Project Structure](../README.md#project-structure)** - Codebase organization and module layout
 
 ### 💼 **Core Systems Documentation**
 
-#### � **Simulation Systems**
+#### ⚙️ **Simulation Systems**
+
 - **[Simulation Loop](design/sim_loop.md)** - Core game loop design and system ordering
-- **[TUI Shell](design/tui_shell.md)** - Ratatui + Crossterm terminal UI, update loop, overlays
 - **[AI & Job System](design/ai_jobs.md)** - Job assignment, AI behavior, and task management
 - **[Designation Lifecycle](design/designation_lifecycle.md)** - Player designation system and state management
 - **[Mining, Items & Stockpiles](design/mining_items_stockpiles.md)** - Complete mining-to-storage pipeline
+- **[TUI Shell Prototype](design/tui_shell.md)** - Terminal UI shell architecture, update loop, and overlays
 
 #### 🌍 **World & Spatial Systems**
+
 - **[World Generation](design/worldgen.md)** - Procedural world creation and terrain generation
 - **[Pathfinding](design/pathfinding.md)** - A* implementation, caching, and navigation systems
 
 #### 💾 **Data & Persistence**
+
 - **[Save/Load System](design/save_load.md)** - Serialization, persistence, and versioning
 - **[Data Structures](../crates/gc_core/src/components.rs)** - Core ECS components and data layout
 
@@ -67,23 +72,27 @@ docs/
 ## 🔍 Documentation by Topic
 
 ### 🎯 **For New Contributors**
+
 1. Start with **[Main README](../README.md)** for project overview
 2. Read **[System Overview](architecture/01_overview.md)** for architecture understanding
 3. Review **[Simulation Loop](design/sim_loop.md)** for execution flow
 4. Check **[AI & Job System](design/ai_jobs.md)** for core mechanics
 
 ### 🔧 **For Core Developers**
+
 1. **[Architecture Decisions](architecture/adr/)** - Understanding past decisions
 2. **[Designation Lifecycle](design/designation_lifecycle.md)** - State management patterns
 3. **[Mining Pipeline](design/mining_items_stockpiles.md)** - Complex system interactions
 4. **[Save/Load System](design/save_load.md)** - Data persistence strategies
 
 ### 🎮 **For Game Designers**
+
 1. **[AI & Job System](design/ai_jobs.md)** - Gameplay mechanics and AI behavior
 2. **[World Generation](design/worldgen.md)** - Content generation systems
 3. **[Master Plan](plan/MASTER_PLAN.md)** - Long-term feature roadmap
 
 ### 🏗️ **For System Architects**
+
 1. **[System Overview](architecture/01_overview.md)** - High-level architecture
 2. **[Architecture Decision Records](architecture/adr/)** - Decision rationale
 3. **[Simulation Loop](design/sim_loop.md)** - System integration patterns
@@ -98,7 +107,7 @@ This documentation is automatically deployed to **[GitHub Pages](https://acarado
 - 🔍 **Search functionality** across all documentation
 - 📱 **Mobile-responsive design** for all devices
 - 🔗 **Cross-reference linking** between documents
-- � **Auto-generated table of contents** for long documents
+- 🧭 **Auto-generated table of contents** for long documents
 
 ---
 
@@ -107,18 +116,21 @@ This documentation is automatically deployed to **[GitHub Pages](https://acarado
 When contributing to documentation:
 
 ### 📝 **Content Standards**
+
 - Use clear, concise language with technical precision
 - Include code examples and diagrams where helpful
 - Link to relevant source code using relative paths
 - Update cross-references when moving or renaming files
 
 ### 🎨 **Formatting Conventions**
+
 - Use emojis sparingly but consistently for visual organization
 - Follow markdown best practices for headers and lists
 - Include `---` horizontal rules to separate major sections
 - Use `> *Italics in quotes*` for emphasis and callouts
 
 ### 🔗 **Linking Best Practices**
+
 - Use relative paths for internal documentation links
 - Link to specific line numbers in source code when relevant
 - Include contextual information for external links
@@ -140,4 +152,4 @@ For technical questions about the documentation system or suggestions for improv
 
 ---
 
-*📚 Documentation maintained by the Goblin Camp development team*
+📚 Documentation maintained by the Goblin Camp development team.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ This directory contains the complete design documentation, architectural decisio
 
 #### � **Simulation Systems**
 - **[Simulation Loop](design/sim_loop.md)** - Core game loop design and system ordering
+- **[TUI Shell](design/tui_shell.md)** - Ratatui + Crossterm terminal UI, update loop, overlays
 - **[AI & Job System](design/ai_jobs.md)** - Job assignment, AI behavior, and task management
 - **[Designation Lifecycle](design/designation_lifecycle.md)** - Player designation system and state management
 - **[Mining, Items & Stockpiles](design/mining_items_stockpiles.md)** - Complete mining-to-storage pipeline

--- a/docs/design/tui_shell.md
+++ b/docs/design/tui_shell.md
@@ -1,0 +1,103 @@
+# M3 — TUI Shell (ratatui + crossterm), Update Loop, Overlays
+
+Status: Draft
+Owner: @acaradonna
+Refs: docs/plan/MASTER_PLAN.md, issue #27
+
+## Goals
+
+- Provide an interactive TUI shell to visualize the headless simulation.
+- Keep core determinism intact; TUI is purely a view/controller around `gc_core`.
+- Implement a minimal update loop with pause/resume and step.
+- Support simple overlays (visibility/FOV) and responsive layout.
+- Keep CLI demos as CI canonical paths; TUI is for local dev and UX prototyping.
+
+Non-goals (M3):
+
+- Full-featured input rebinding or mouse-driven UI.
+- Complex widgets; we favor a simple ASCII map first.
+- ECS in TUI crate; ECS remains in `gc_core`.
+
+## Crate Layout
+
+- `crates/gc_tui/` — TUI crate using `ratatui` + `crossterm`.
+  - `src/lib.rs` exposes `run(width, height, seed) -> Result<()>` plus helpers:
+    - `build_world(width, height, seed) -> World`
+    - `build_schedule() -> Schedule`
+    - `AppState { paused, show_vis, steps_per_frame }`
+    - Internal `draw(frame, world, app)` and `step_sim(world, schedule, app)`
+- `crates/gc_cli/` adds a `tui` subcommand that calls `gc_tui::run`.
+
+This mirrors the headless-first approach: `gc_core` owns data/systems, TUI/CLI are thin shells.
+
+## Rendering Plan
+
+- Renderer: Start with simple ASCII map using `Paragraph` and join of rows.
+- Layout: Header, main area, status/footer using `Layout::vertical([1, Min(0), 1])`.
+- Overlays: Optional visibility overlay draws `*` where visible.
+- Agents/Entities: Future M3+ iteration could render entity markers on top.
+
+## Update Loop
+
+- Tick source: `gc_core::systems::Time::new(100)` fixed-tick resource.
+- Per-frame behavior:
+  - Draw frame.
+  - Poll input for ~16ms to avoid blocking.
+  - Apply input: toggle pause, step (`.`), toggle vis (`v`), change steps-per-frame via `1-9`.
+  - If not paused, run `steps_per_frame` iterations of `schedule.run(&mut world)`.
+  - If visibility is enabled, run FOV system pass per frame.
+- Exit on `q` or `Esc`.
+
+## Input Map (initial)
+
+- `q`/`Esc`: quit
+- `Space`: pause/resume
+- `.`: single-step once
+- `v`: toggle visibility overlay
+- `1`..`9`: set steps-per-frame
+
+## Determinism
+
+- Seeded RNG resource `systems::DeterministicRng` injected.
+- All random operations done through the resource; no `std::time` in sim.
+- TUI does not affect sim determinism across runs when receiving the same input sequence.
+
+## Error Handling and Exit
+
+- Use `ratatui::init()`/`ratatui::restore()` to manage alternate screen/raw mode and panic hook.
+- Clean restore on normal exit and errors.
+
+## Testing Strategy
+
+- Keep core integration tests unchanged; TUI is not tested in CI yet.
+- Optional future: a golden-buffer snapshot test using `ratatui::buffer::Buffer` + a fake backend to assert ASCII output for a known small map.
+
+## Performance Notes
+
+- Drawing with `Paragraph` is simple but not optimal; when needed, move to a custom `Widget` that writes directly to the frame buffer for better performance.
+- Event poll duration is small; can be adjusted or moved to a timer approach.
+
+## Future Extensions
+
+- Agent markers and selection cursor; highlight tile details.
+- Sidebar panels (jobs, entities, stockpiles) using a split layout.
+- Input abstraction and keybind configuration.
+- Snapshot tests for rendering.
+- Frame pacing controls (vsync-like sleeps) and FPS display.
+
+## Risks
+
+- Terminal compatibility differences; use crossterm defaults and avoid non-portable features.
+- Performance for large maps; keep ASCII path and measure.
+
+## Acceptance Criteria
+
+- `cargo run -p gc_cli -- tui` launches TUI in alternate screen and displays the map.
+- Can pause/resume, step once, toggle visibility overlay, adjust steps-per-frame.
+- Exits cleanly with terminal restored.
+
+## References
+
+- Ratatui docs: <https://docs.rs/ratatui>
+- Event handling with crossterm: <https://docs.rs/crossterm/latest/crossterm/event>
+- Application patterns: <https://ratatui.rs/concepts/application-patterns/>


### PR DESCRIPTION
[M3] TUI shell design + prototype

This PR introduces a terminal UI (Ratatui + Crossterm) prototype and a design doc.

Highlights
- New crate `gc_tui` with an interactive TUI loop (pause/step/visibility overlay, steps-per-frame)
- CLI `tui` subcommand wired into `gc_cli`
- Design doc: `docs/design/tui_shell.md`
- Deterministic ECS preserved; TUI is a thin IO shell around gc_core

## How to run

- TUI:
  - `cargo run -p gc_cli -- tui`
  - Optional: `cargo run -p gc_cli -- --width 100 --height 60 --seed 123 tui`
- Validation (local):
  - `./dev.sh check`

Controls: q/Esc quit, space pause/resume, `.` step, `v` toggle visibility, `1–9` steps-per-frame.

## Notes
- Kept CLI demos as CI canonical; TUI for local dev/UX prototyping
- Future: entity markers, panel splits, golden-buffer snapshot tests

Refs: #27
