### PR TITLE
gc_core: bootstrap world + schedule; wire CLI/TUI (fixes #30)

### DIFF
--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -5,9 +5,7 @@ use gc_core::bootstrap::{
     build_default_schedule as core_build_default_schedule, build_standard_world, WorldOptions,
 };
 use gc_core::prelude::*;
-use gc_core::stockpiles::StockpileBundle;
-use gc_core::{designations, jobs, save, systems};
-use rand::Rng;
+use gc_core::{designations, save};
 use std::io::{self, Write};
 
 #[derive(Subcommand, Debug, Clone)]

--- a/crates/gc_core/src/bootstrap.rs
+++ b/crates/gc_core/src/bootstrap.rs
@@ -1,0 +1,107 @@
+//! Bootstrap utilities for building a standard world and schedule
+//! shared by both CLI demos and the TUI. Keeping this in `gc_core`
+//! ensures a single source of truth for setup and determinism.
+
+use bevy_ecs::prelude::*;
+use rand::Rng;
+
+use crate::designations;
+use crate::jobs;
+use crate::prelude::*;
+use crate::stockpiles::StockpileBundle;
+use crate::systems;
+
+/// Options controlling what entities/resources to include when building a world.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WorldOptions {
+    /// If true, spawns a small demo scene with a miner, a carrier, and a stockpile.
+    pub populate_demo_scene: bool,
+    /// Initial time tick duration in ms (fixed-step). Defaults to 100.
+    pub tick_ms: u64,
+}
+
+impl WorldOptions {
+    pub fn new() -> Self {
+        Self {
+            populate_demo_scene: false,
+            tick_ms: 100,
+        }
+    }
+}
+
+/// Build a standard world with deterministic RNG, generated map, job systems,
+/// and optional demo population. This is the canonical entry point for shells.
+pub fn build_standard_world(width: u32, height: u32, seed: u64, opts: WorldOptions) -> World {
+    let mut world = World::new();
+
+    // Deterministic RNG first so any subsequent randomness draws from it
+    world.insert_resource(systems::DeterministicRng::new(seed));
+
+    // Map generation via centralized RNG
+    let gen = MapGenerator::new();
+    let mapgen_seed = {
+        let mut rng = world.resource_mut::<systems::DeterministicRng>();
+        rng.mapgen_rng.gen::<u32>()
+    };
+    let map = gen.generate(width, height, mapgen_seed);
+    world.insert_resource(map);
+
+    // Core resources
+    world.insert_resource(JobBoard::default());
+    world.insert_resource(jobs::ItemSpawnQueue::default());
+    world.insert_resource(jobs::ActiveJobs::default());
+    world.insert_resource(designations::DesignationConfig { auto_jobs: true });
+    world.insert_resource(systems::Time::new(opts.tick_ms));
+
+    if opts.populate_demo_scene {
+        // Miner
+        world.spawn((
+            Name("Grak".into()),
+            Position(5, 5),
+            Velocity(0, 0),
+            Miner,
+            AssignedJob::default(),
+            VisionRadius(8),
+        ));
+
+        // Carrier
+        world.spawn((
+            Name("Urok".into()),
+            Position(5, 5),
+            Velocity(0, 0),
+            Carrier,
+            Inventory::default(),
+            AssignedJob::default(),
+            VisionRadius(8),
+        ));
+
+        // Stockpile zone centered around (10,10)
+        world
+            .spawn(StockpileBundle::new(9, 9, 11, 11))
+            .insert(Name("Stockpile".into()));
+    }
+
+    world
+}
+
+/// Build the default simulation schedule used by shells for demos/play.
+pub fn build_default_schedule() -> Schedule {
+    let mut schedule = Schedule::default();
+    schedule.add_systems((
+        systems::movement,
+        systems::confine_to_map,
+        (
+            designations::designation_dedup_system,
+            designations::designation_to_jobs_system,
+            jobs::job_assignment_system,
+        )
+            .chain(),
+        (
+            jobs::mine_job_execution_system,
+            systems::hauling_execution_system,
+            systems::auto_haul_system,
+        ),
+        systems::advance_time,
+    ));
+    schedule
+}

--- a/crates/gc_core/src/lib.rs
+++ b/crates/gc_core/src/lib.rs
@@ -103,6 +103,7 @@ impl ActionLog {
 /// // Now you have access to Position, GameMap, JobBoard, etc.
 /// ```
 pub mod prelude {
+    pub use crate::bootstrap::*;
     pub use crate::components::*;
     pub use crate::designations::*;
     pub use crate::fov::*;
@@ -142,5 +143,8 @@ pub mod stockpiles;
 pub mod systems;
 /// Spatial world representation and tile management
 pub mod world;
+
+/// Bootstrap helpers for building standard worlds and schedules shared by CLI/TUI
+pub mod bootstrap;
 
 // Removed empty internal tests module; tests live in `tests/` integration folder.

--- a/crates/gc_tui/src/lib.rs
+++ b/crates/gc_tui/src/lib.rs
@@ -7,8 +7,6 @@ use gc_core::bootstrap::{
 };
 use gc_core::fov;
 use gc_core::prelude::*;
-use gc_core::{designations, jobs, systems};
-use rand::Rng;
 use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},


### PR DESCRIPTION
Implements #30: Shared core world and schedule builders for CLI/TUI\n\nSummary\n- Add gc_core::bootstrap with WorldOptions, build_standard_world, build_default_schedule\n- Refactor gc_cli and gc_tui to use shared builders; keep CLI as CI/default path\n- Preserve determinism (seeded RNG, fixed tick) and TUI-specific FOV overlay\n\nRationale\nAvoids drift between CLI and TUI setups, centralizes wiring, and makes demos/tests consistent.\n\nValidation\n- ./dev.sh check (format, clippy, tests, doc tests) passes\n- Demos: mapgen, fov (with --show-vis), path, save-load, path-batch all run\n\nNotes\n- Jobs demo still has known ECS query conflict (unchanged)\n- Minor clippy cleanup: removed unused imports\n\n