### PR TITLE
feat(save): add CBOR codec and --codec cbor (Fixes #158)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ name = "gc_core"
 version = "0.1.0"
 dependencies = [
  "bevy_ecs",
+ "ciborium",
  "criterion",
  "lru",
  "noise",

--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -52,7 +52,7 @@ struct Args {
     #[arg(long, default_value_t = false)]
     show_vis: bool,
 
-    /// Codec for save/load demo: json|ron (default: json)
+    /// Codec for save/load demo: json|ron|cbor (default: json)
     #[arg(long, default_value = "json")]
     codec: String,
 
@@ -383,7 +383,6 @@ fn run_demo_save(args: &Args) -> Result<()> {
             );
         }
         other => {
-<<<<<<< HEAD
             return Err(anyhow::anyhow!(
                 "Unknown codec '{}', use json|ron (default json)",
                 other
@@ -420,11 +419,6 @@ fn run_demo_zones(args: &Args) -> Result<()> {
         let map = world.resource::<GameMap>();
         print_ascii_map_with_zones(map, &zones);
     }
-=======
-            println!("Unknown codec '{}', use json|ron (default json)", other);
-        }
-    }
->>>>>>> 19e9236 (core(save): add RON codec helpers (encode/decode))
     Ok(())
 }
 

--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -382,9 +382,22 @@ fn run_demo_save(args: &Args) -> Result<()> {
                 world2.resource::<GameMap>().height
             );
         }
+        "cbor" => {
+            let bytes = save::encode_cbor(&save).map_err(|e| anyhow::anyhow!(e))?;
+            println!("Serialized (cbor) length: {} bytes", bytes.len());
+            let parsed: save::SaveGame =
+                save::decode_cbor(&bytes).map_err(|e| anyhow::anyhow!(e))?;
+            let mut world2 = World::new();
+            load_world(parsed, &mut world2);
+            println!(
+                "Reloaded world with {}x{} map.",
+                world2.resource::<GameMap>().width,
+                world2.resource::<GameMap>().height
+            );
+        }
         other => {
             return Err(anyhow::anyhow!(
-                "Unknown codec '{}', use json|ron (default json)",
+                "Unknown codec '{}', use json|ron|cbor (default json)",
                 other
             ));
         }

--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -383,6 +383,7 @@ fn run_demo_save(args: &Args) -> Result<()> {
             );
         }
         other => {
+<<<<<<< HEAD
             return Err(anyhow::anyhow!(
                 "Unknown codec '{}', use json|ron (default json)",
                 other
@@ -419,6 +420,11 @@ fn run_demo_zones(args: &Args) -> Result<()> {
         let map = world.resource::<GameMap>();
         print_ascii_map_with_zones(map, &zones);
     }
+=======
+            println!("Unknown codec '{}', use json|ron (default json)", other);
+        }
+    }
+>>>>>>> 19e9236 (core(save): add RON codec helpers (encode/decode))
     Ok(())
 }
 

--- a/crates/gc_core/Cargo.toml
+++ b/crates/gc_core/Cargo.toml
@@ -12,6 +12,7 @@ bevy_ecs = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ron = "0.8"
+ciborium = { version = "0.2", features = ["std"] }
 rand = "0.8"
 thiserror = "1.0"
 pathfinding = "4.9.0"

--- a/crates/gc_core/src/save.rs
+++ b/crates/gc_core/src/save.rs
@@ -97,6 +97,10 @@ pub fn encode_ron(save: &SaveGame) -> Result<String, ron::Error> {
 
 /// Decode a SaveGame from RON string
 pub fn decode_ron(s: &str) -> Result<SaveGame, ron::Error> {
+<<<<<<< HEAD
     // ron 0.8: from_str returns ron::de::SpannedError; convert to ron::Error
     ron::de::from_str::<SaveGame>(s).map_err(ron::Error::from)
+=======
+    ron::de::from_str(s).map_err(ron::Error::from)
+>>>>>>> 19e9236 (core(save): add RON codec helpers (encode/decode))
 }

--- a/crates/gc_core/src/save.rs
+++ b/crates/gc_core/src/save.rs
@@ -2,6 +2,7 @@ use crate::components::{Carriable, Item, ItemType};
 use crate::world::{GameMap, Name, Position, TileKind, Velocity};
 use bevy_ecs::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::io::Cursor;
 
 #[derive(Serialize, Deserialize)]
 pub struct SaveGame {
@@ -97,10 +98,19 @@ pub fn encode_ron(save: &SaveGame) -> Result<String, ron::Error> {
 
 /// Decode a SaveGame from RON string
 pub fn decode_ron(s: &str) -> Result<SaveGame, ron::Error> {
-<<<<<<< HEAD
     // ron 0.8: from_str returns ron::de::SpannedError; convert to ron::Error
     ron::de::from_str::<SaveGame>(s).map_err(ron::Error::from)
-=======
-    ron::de::from_str(s).map_err(ron::Error::from)
->>>>>>> 19e9236 (core(save): add RON codec helpers (encode/decode))
+}
+
+/// Encode a SaveGame to CBOR bytes
+pub fn encode_cbor(save: &SaveGame) -> Result<Vec<u8>, ciborium::ser::Error<std::io::Error>> {
+    let mut buf = Vec::new();
+    ciborium::ser::into_writer(save, &mut buf)?;
+    Ok(buf)
+}
+
+/// Decode a SaveGame from CBOR bytes
+pub fn decode_cbor(bytes: &[u8]) -> Result<SaveGame, ciborium::de::Error<std::io::Error>> {
+    let mut cur = Cursor::new(bytes);
+    ciborium::de::from_reader(&mut cur)
 }


### PR DESCRIPTION
Adds CBOR encode/decode helpers in core and wires --codec cbor to the save-load CLI demo.

- Core: encode_cbor/decode_cbor via ciborium
- CLI: --codec supports json|ron|cbor (default json), errors on invalid
- Lockfile updated

Determinism preserved; logical schema unchanged.

Depends on RON PR now merged.

Fixes #158