### PR TITLE
core(schedule): process ItemSpawnQueue after mining (Fixes #229)

### DIFF
--- a/crates/gc_core/src/bootstrap.rs
+++ b/crates/gc_core/src/bootstrap.rs
@@ -96,8 +96,11 @@ pub fn build_default_schedule() -> Schedule {
             jobs::job_assignment_system,
         )
             .chain(),
+        // Execute jobs, then materialize any queued spawns before downstream systems
+        // This ensures items created by mining exist before auto_haul runs.
         (
             jobs::mine_job_execution_system,
+            jobs::process_item_spawn_queue_system,
             systems::hauling_execution_system,
             systems::auto_haul_system,
         ),


### PR DESCRIPTION
## Summary
- Fix Jobs demo regression where mining produced no stone items
- Add `jobs::process_item_spawn_queue_system` to default schedule after mining
- Ensures item spawns are materialized before `auto_haul` creates haul jobs

## Details
Mining enqueues `ItemSpawnRequest` but the default schedule never processed the queue, so items never appeared in-world. By inserting the queue processing system immediately after `mine_job_execution_system`, stone items appear in the same tick and auto-haul can generate haul jobs for them.

## Validation
- Ran `./dev.sh validate` locally: format, clippy, build, tests (unit+doc), and demo validation all green
- Verified Jobs demo now shows 1 stone at mined tile and haul jobs are created

## Notes
- This decouples item creation from execution timing and reduces ordering footguns
- No behavior change for other systems; strictly corrects missing queue processing

Fixes #229