### PR TITLE
save-load: autosave slots + crash recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive integration tests covering all deduplication scenarios
   - Proper system ordering using Bevy's `.chain()` for deterministic execution
 
+#### 💾 **Autosave & Crash Recovery**
+
+- **Tick-based autosave cadence** with rotating slots and per-slot backups
+  - `gc_core::autosave` module (`AutosaveManager`, `recover_latest_autosave`, `SaveCodec`)
+  - Atomic slot writes with `.bak` rollback for crash/corruption tolerance
+  - Golden fixtures + recovery tests for truncation/corruption scenarios
+- **CLI recovery workflow**
+  - `gc_cli` flags: `--autosave-every`, `--autosave-slots`, `--autosave-dir`, `--autosave-codec`, `--load-autosave`
+  - Interactive recovery prompt when an unclean shutdown is detected via `autosave.lock`
+
 ### Fixed
 
 - **Mining job execution** - Fixed wall-to-floor conversion and item spawning

--- a/crates/gc_cli/src/main.rs
+++ b/crates/gc_cli/src/main.rs
@@ -1,12 +1,16 @@
 use anyhow::Result;
 use bevy_ecs::prelude::*;
 use clap::{Parser, Subcommand};
+use gc_core::autosave::{recover_latest_autosave, AutosaveConfig, AutosaveManager, SaveCodec};
 use gc_core::bootstrap::{
     build_default_schedule as core_build_default_schedule, build_standard_world, WorldOptions,
 };
 use gc_core::prelude::*;
 use gc_core::{designations, save};
+use std::fs;
+use std::io::IsTerminal;
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 #[derive(Subcommand, Debug, Clone)]
 enum Demo {
@@ -54,6 +58,30 @@ struct Args {
     #[arg(long, default_value = "json")]
     codec: String,
 
+    /// Enable autosave every N simulation ticks (0 disables autosave)
+    #[arg(long, default_value_t = 0)]
+    autosave_every: u64,
+
+    /// Number of rotating autosave slots to keep
+    #[arg(long, default_value_t = 3)]
+    autosave_slots: usize,
+
+    /// Directory to store autosave files (used when autosave is enabled)
+    #[arg(long, default_value = "autosaves")]
+    autosave_dir: String,
+
+    /// Codec for autosaves: json|ron|cbor (default: json)
+    #[arg(long, default_value = "json")]
+    autosave_codec: String,
+
+    /// Load the newest autosave (if present) before running the demo
+    #[arg(long, default_value_t = false)]
+    load_autosave: bool,
+
+    /// Disable interactive crash-recovery prompt on startup
+    #[arg(long, default_value_t = false)]
+    no_recovery_prompt: bool,
+
     /// Choose a demo to run. If omitted or set to `menu`, an interactive picker is shown.
     #[command(subcommand)]
     demo: Option<Demo>,
@@ -97,7 +125,7 @@ fn print_ascii_map_with_path(map: &GameMap, path: &[(i32, i32)]) {
     }
 }
 
-fn build_world(args: &Args) -> World {
+fn build_fresh_world(args: &Args) -> World {
     build_standard_world(
         args.width,
         args.height,
@@ -109,12 +137,70 @@ fn build_world(args: &Args) -> World {
     )
 }
 
+fn build_world_from_save(save_game: save::SaveGame) -> World {
+    // Build a canonical world with required resources, but do not spawn demo entities.
+    // The saved snapshot will spawn entities and override map/time/rng resources.
+    let mut world = build_standard_world(
+        save_game.width,
+        save_game.height,
+        save_game.master_seed,
+        WorldOptions {
+            populate_demo_scene: false,
+            tick_ms: save_game.tick_ms,
+        },
+    );
+    save::load_world(save_game, &mut world);
+    world
+}
+
+fn parse_save_codec(s: &str) -> Result<SaveCodec> {
+    match s {
+        "json" => Ok(SaveCodec::Json),
+        "ron" => Ok(SaveCodec::Ron),
+        "cbor" => Ok(SaveCodec::Cbor),
+        other => anyhow::bail!("Unknown codec '{}'. Use one of: json|ron|cbor", other),
+    }
+}
+
+struct AutosaveSessionLock {
+    path: PathBuf,
+}
+
+impl AutosaveSessionLock {
+    fn lock_path(dir: &Path) -> PathBuf {
+        dir.join("autosave.lock")
+    }
+
+    fn acquire(dir: &Path) -> Result<Self> {
+        fs::create_dir_all(dir)?;
+        let path = Self::lock_path(dir);
+        fs::write(&path, format!("pid={}\n", std::process::id()))?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for AutosaveSessionLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn prompt_yes_no(prompt: &str) -> bool {
+    print!("{prompt}");
+    let _ = io::stdout().flush();
+    let mut buf = String::new();
+    if io::stdin().read_line(&mut buf).is_ok() {
+        matches!(buf.trim().to_lowercase().as_str(), "y" | "yes")
+    } else {
+        false
+    }
+}
+
 fn build_default_schedule() -> Schedule {
     core_build_default_schedule()
 }
 
-fn run_demo_mapgen(args: &Args) -> Result<()> {
-    let world = build_world(args);
+fn run_demo_mapgen(args: &Args, world: &World) -> Result<()> {
     let map = world.resource::<GameMap>();
     if args.ascii_map {
         print_ascii_map(map);
@@ -123,14 +209,13 @@ fn run_demo_mapgen(args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn run_demo_fov(args: &Args) -> Result<()> {
-    let mut world = build_world(args);
+fn run_demo_fov(args: &Args, world: &mut World) -> Result<()> {
     world.insert_resource(gc_core::fov::Visibility::default());
 
     // Compute visibility
     let mut schedule = Schedule::default();
     schedule.add_systems((gc_core::fov::compute_visibility_system,));
-    schedule.run(&mut world);
+    schedule.run(world);
 
     // Print result
     let map = world.resource::<GameMap>();
@@ -171,8 +256,7 @@ fn run_demo_fov(args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn run_demo_path(args: &Args) -> Result<()> {
-    let world = build_world(args);
+fn run_demo_path(args: &Args, world: &World) -> Result<()> {
     let map = world.resource::<GameMap>();
     let start = (1, 1);
     let goal = (args.width as i32 - 2, args.height as i32 - 2);
@@ -188,8 +272,7 @@ fn run_demo_path(args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn run_demo_path_batch(args: &Args) -> Result<()> {
-    let world = build_world(args);
+fn run_demo_path_batch(args: &Args, world: &World) -> Result<()> {
     let map = world.resource::<GameMap>();
     let mut svc = gc_core::path::PathService::new(256);
 
@@ -221,9 +304,11 @@ fn run_demo_path_batch(args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn run_demo_jobs(args: &Args) -> Result<()> {
-    let mut world = build_world(args);
-
+fn run_demo_jobs(
+    args: &Args,
+    world: &mut World,
+    autosave: &mut Option<AutosaveManager>,
+) -> Result<()> {
     // Set a wall tile at (5,5) for mining
     {
         let mut map = world.resource_mut::<GameMap>();
@@ -251,12 +336,15 @@ fn run_demo_jobs(args: &Args) -> Result<()> {
     // Run simulation for the specified steps
     let mut schedule = build_default_schedule();
     for _step in 0..args.steps {
-        schedule.run(&mut world);
+        schedule.run(world);
+        if let Some(mgr) = autosave.as_mut() {
+            let _ = mgr.maybe_autosave(world).map_err(|e| anyhow::anyhow!(e))?;
+        }
     }
 
     // Print assignments and results
     let mut q = world.query::<(&Name, &AssignedJob)>();
-    for (name, aj) in q.iter(&world) {
+    for (name, aj) in q.iter(world) {
         if let Some(job_id) = aj.0 {
             println!("{} assigned: {}", name.0, job_id.0);
         } else {
@@ -266,11 +354,11 @@ fn run_demo_jobs(args: &Args) -> Result<()> {
 
     // Print miner and carrier positions
     let mut q_miners = world.query_filtered::<(&Name, &Position), With<Miner>>();
-    for (name, pos) in q_miners.iter(&world) {
+    for (name, pos) in q_miners.iter(world) {
         println!("{} (Miner) at: ({}, {})", name.0, pos.0, pos.1);
     }
     let mut q_carriers = world.query_filtered::<(&Name, &Position, &Inventory), With<Carrier>>();
-    for (name, pos, inv) in q_carriers.iter(&world) {
+    for (name, pos, inv) in q_carriers.iter(world) {
         println!(
             "{} (Carrier) at: ({}, {}) carrying {}",
             name.0,
@@ -282,9 +370,9 @@ fn run_demo_jobs(args: &Args) -> Result<()> {
 
     // Print items created
     let mut q_items = world.query::<(&Position, &Stone)>();
-    let item_count = q_items.iter(&world).count();
+    let item_count = q_items.iter(world).count();
     println!("Stone items in world: {}", item_count);
-    for (pos, _) in q_items.iter(&world) {
+    for (pos, _) in q_items.iter(world) {
         println!("  Stone at: ({}, {})", pos.0, pos.1);
     }
 
@@ -293,10 +381,10 @@ fn run_demo_jobs(args: &Args) -> Result<()> {
     let bounds: Vec<gc_core::components::ZoneBounds> = {
         let mut q_bounds =
             world.query_filtered::<&gc_core::components::ZoneBounds, With<Stockpile>>();
-        q_bounds.iter(&world).cloned().collect()
+        q_bounds.iter(world).cloned().collect()
     };
     let mut hauled_count = 0usize;
-    for (pos, _) in q_items.iter(&world) {
+    for (pos, _) in q_items.iter(world) {
         if bounds.iter().any(|b| b.contains(pos.0, pos.1)) {
             hauled_count += 1;
         }
@@ -331,9 +419,8 @@ fn run_demo_jobs(args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn run_demo_save(args: &Args) -> Result<()> {
-    let mut world = build_world(args);
-    let save = save_world(&mut world);
+fn run_demo_save(args: &Args, world: &mut World) -> Result<()> {
+    let save = save_world(world);
     match args.codec.as_str() {
         "json" => {
             let data = save::encode_json(&save)?;
@@ -412,18 +499,78 @@ fn interactive_pick() -> Demo {
 fn main() -> Result<()> {
     let args = Args::parse();
 
+    let autosave_dir = PathBuf::from(&args.autosave_dir);
+    let autosave_codec = parse_save_codec(&args.autosave_codec)?;
+    let autosave_config = AutosaveConfig {
+        every_ticks: args.autosave_every,
+        slots: args.autosave_slots,
+        codec: autosave_codec,
+        base_name: "autosave".to_string(),
+    };
+
+    let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+    let crashed = AutosaveSessionLock::lock_path(&autosave_dir).exists();
+
+    // Decide whether to load a recovery autosave.
+    let mut recovered_save: Option<save::SaveGame> = None;
+    let mut want_load_autosave = args.load_autosave;
+
+    if crashed && interactive && !args.no_recovery_prompt && !want_load_autosave {
+        if let Some(candidate) = recover_latest_autosave(&autosave_dir, &autosave_config)
+            .map_err(|e| anyhow::anyhow!("autosave recovery scan failed: {e}"))?
+        {
+            println!(
+                "⚠️ Detected an unclean shutdown. Latest autosave: {} (ticks={})",
+                candidate.path.display(),
+                candidate.save.ticks
+            );
+            if prompt_yes_no("Recover this autosave? [y/N]: ") {
+                want_load_autosave = true;
+                recovered_save = Some(candidate.save);
+            }
+        }
+    }
+
+    if want_load_autosave && recovered_save.is_none() {
+        recovered_save = recover_latest_autosave(&autosave_dir, &autosave_config)
+            .map_err(|e| anyhow::anyhow!("autosave recovery scan failed: {e}"))?
+            .map(|c| c.save);
+        if recovered_save.is_none() {
+            println!("No valid autosave found in {}", autosave_dir.display());
+        }
+    }
+
     let chosen = match args.demo.clone().unwrap_or(Demo::Menu) {
         Demo::Menu => interactive_pick(),
         other => other,
     };
 
+    let mut world = match recovered_save {
+        Some(save_game) => build_world_from_save(save_game),
+        None => build_fresh_world(&args),
+    };
+
+    // If autosave writing is enabled, acquire a session lock and initialize a manager.
+    let mut autosave_mgr: Option<AutosaveManager> = None;
+    let _autosave_lock = if autosave_config.enabled() {
+        let lock = AutosaveSessionLock::acquire(&autosave_dir)?;
+        let mut mgr =
+            AutosaveManager::new(&autosave_dir, autosave_config).map_err(|e| anyhow::anyhow!(e))?;
+        mgr.sync_last_saved_tick_from_world(&world)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        autosave_mgr = Some(mgr);
+        Some(lock)
+    } else {
+        None
+    };
+
     match chosen {
-        Demo::Mapgen => run_demo_mapgen(&args),
-        Demo::Fov => run_demo_fov(&args),
-        Demo::Path => run_demo_path(&args),
-        Demo::Jobs => run_demo_jobs(&args),
-        Demo::SaveLoad => run_demo_save(&args),
-        Demo::PathBatch => run_demo_path_batch(&args),
+        Demo::Mapgen => run_demo_mapgen(&args, &world),
+        Demo::Fov => run_demo_fov(&args, &mut world),
+        Demo::Path => run_demo_path(&args, &world),
+        Demo::Jobs => run_demo_jobs(&args, &mut world, &mut autosave_mgr),
+        Demo::SaveLoad => run_demo_save(&args, &mut world),
+        Demo::PathBatch => run_demo_path_batch(&args, &world),
         Demo::Tui => gc_tui::run(args.width, args.height, args.seed),
         Demo::Menu => Ok(()),
     }

--- a/crates/gc_core/src/autosave.rs
+++ b/crates/gc_core/src/autosave.rs
@@ -1,0 +1,365 @@
+//! Autosave and crash recovery helpers.
+//!
+//! This module builds on `crate::save` by providing:
+//! - Periodic autosaves on a deterministic tick cadence (based on `systems::Time::ticks`)
+//! - Rotating save slots on disk
+//! - Recovery helpers that pick the newest valid save (by in-save tick counter)
+//!
+//! Notes:
+//! - Autosave cadence is based on simulation ticks, not wall-clock time, to preserve determinism.
+//! - File IO is performed with a simple atomic-write pattern that leaves a per-slot `.bak` backup.
+
+use crate::save::{self, SaveGame};
+use crate::systems::Time;
+use bevy_ecs::prelude::World;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Supported codecs for autosave files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveCodec {
+    Json,
+    Ron,
+    Cbor,
+}
+
+impl SaveCodec {
+    pub fn extension(self) -> &'static str {
+        match self {
+            SaveCodec::Json => "json",
+            SaveCodec::Ron => "ron",
+            SaveCodec::Cbor => "cbor",
+        }
+    }
+}
+
+/// Autosave configuration.
+#[derive(Debug, Clone)]
+pub struct AutosaveConfig {
+    /// Save every N simulation ticks (0 disables autosave).
+    pub every_ticks: u64,
+    /// Number of rotating slots to keep (0 disables autosave).
+    pub slots: usize,
+    /// Codec used for save bytes on disk.
+    pub codec: SaveCodec,
+    /// File prefix used for slot naming (e.g. `autosave-0.json`).
+    pub base_name: String,
+}
+
+impl AutosaveConfig {
+    pub fn enabled(&self) -> bool {
+        self.every_ticks > 0 && self.slots > 0
+    }
+}
+
+impl Default for AutosaveConfig {
+    fn default() -> Self {
+        Self {
+            every_ticks: 0,
+            slots: 3,
+            codec: SaveCodec::Json,
+            base_name: "autosave".to_string(),
+        }
+    }
+}
+
+/// Result returned by recovery helpers.
+#[derive(Debug, Clone)]
+pub struct RecoveredAutosave {
+    pub save: SaveGame,
+    pub path: PathBuf,
+}
+
+/// Errors for autosave IO and codec operations.
+#[derive(Debug, Error)]
+pub enum AutosaveError {
+    #[error("autosave requires a Time resource in the World")]
+    MissingTime,
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("json codec error at {path}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("ron codec error at {path}: {source}")]
+    Ron {
+        path: PathBuf,
+        #[source]
+        source: ron::Error,
+    },
+    #[error("cbor encode error at {path}: {source}")]
+    CborEncode {
+        path: PathBuf,
+        #[source]
+        source: ciborium::ser::Error<io::Error>,
+    },
+    #[error("cbor decode error at {path}: {source}")]
+    CborDecode {
+        path: PathBuf,
+        #[source]
+        source: ciborium::de::Error<io::Error>,
+    },
+}
+
+/// Manages rotating autosave slots.
+#[derive(Debug)]
+pub struct AutosaveManager {
+    dir: PathBuf,
+    config: AutosaveConfig,
+    next_slot: usize,
+    last_saved_tick: u64,
+}
+
+impl AutosaveManager {
+    pub fn new(dir: impl Into<PathBuf>, config: AutosaveConfig) -> Result<Self, AutosaveError> {
+        let dir = dir.into();
+        if config.enabled() {
+            fs::create_dir_all(&dir).map_err(|e| AutosaveError::Io {
+                path: dir.clone(),
+                source: e,
+            })?;
+        }
+
+        Ok(Self {
+            dir,
+            config,
+            next_slot: 0,
+            last_saved_tick: 0,
+        })
+    }
+
+    pub fn config(&self) -> &AutosaveConfig {
+        &self.config
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn slot_path(&self, slot: usize) -> PathBuf {
+        autosave_slot_path(&self.dir, &self.config.base_name, slot, self.config.codec)
+    }
+
+    pub fn slot_backup_path(&self, slot: usize) -> PathBuf {
+        autosave_slot_backup_path(&self.dir, &self.config.base_name, slot, self.config.codec)
+    }
+
+    /// Create an autosave if the cadence is due.
+    ///
+    /// Returns `Ok(Some(path))` when a save was written.
+    pub fn maybe_autosave(&mut self, world: &mut World) -> Result<Option<PathBuf>, AutosaveError> {
+        if !self.config.enabled() {
+            return Ok(None);
+        }
+
+        let ticks = world
+            .get_resource::<Time>()
+            .map(|t| t.ticks)
+            .ok_or(AutosaveError::MissingTime)?;
+
+        if ticks < self.last_saved_tick.saturating_add(self.config.every_ticks) {
+            return Ok(None);
+        }
+
+        let save_game = save::save_world(world);
+        let slot = self.next_slot % self.config.slots;
+        let path = self.slot_path(slot);
+        write_save_atomic(&path, &save_game, self.config.codec)?;
+
+        self.last_saved_tick = ticks;
+        self.next_slot = (slot + 1) % self.config.slots;
+
+        Ok(Some(path))
+    }
+}
+
+/// Compute the on-disk path for a slot.
+pub fn autosave_slot_path(dir: &Path, base_name: &str, slot: usize, codec: SaveCodec) -> PathBuf {
+    dir.join(format!("{base_name}-{slot}.{}", codec.extension()))
+}
+
+/// Compute the `.bak` path for a slot.
+pub fn autosave_slot_backup_path(
+    dir: &Path,
+    base_name: &str,
+    slot: usize,
+    codec: SaveCodec,
+) -> PathBuf {
+    let primary = autosave_slot_path(dir, base_name, slot, codec);
+    let file_name = primary
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| format!("{base_name}-{slot}.{}", codec.extension()));
+    primary.with_file_name(format!("{file_name}.bak"))
+}
+
+/// Recover the newest valid autosave (highest `SaveGame.ticks`) from a slot set.
+///
+/// This scans both primary slot files and their `.bak` backups, skipping any
+/// corrupted/unreadable entries.
+pub fn recover_latest_autosave(
+    dir: impl AsRef<Path>,
+    config: &AutosaveConfig,
+) -> Result<Option<RecoveredAutosave>, AutosaveError> {
+    if !config.enabled() {
+        return Ok(None);
+    }
+
+    let dir = dir.as_ref();
+    let mut best: Option<RecoveredAutosave> = None;
+
+    for slot in 0..config.slots {
+        let candidates = [
+            autosave_slot_path(dir, &config.base_name, slot, config.codec),
+            autosave_slot_backup_path(dir, &config.base_name, slot, config.codec),
+        ];
+
+        for path in candidates {
+            if !path.exists() {
+                continue;
+            }
+
+            let save = match read_save(&path, config.codec) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            let replace = match &best {
+                None => true,
+                Some(current) => {
+                    save.ticks > current.save.ticks
+                        || (save.ticks == current.save.ticks && path < current.path)
+                }
+            };
+
+            if replace {
+                best = Some(RecoveredAutosave { save, path });
+            }
+        }
+    }
+
+    Ok(best)
+}
+
+fn read_save(path: &Path, codec: SaveCodec) -> Result<SaveGame, AutosaveError> {
+    match codec {
+        SaveCodec::Json => {
+            let data = fs::read_to_string(path).map_err(|e| AutosaveError::Io {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+            save::decode_json(&data).map_err(|e| AutosaveError::Json {
+                path: path.to_path_buf(),
+                source: e,
+            })
+        }
+        SaveCodec::Ron => {
+            let data = fs::read_to_string(path).map_err(|e| AutosaveError::Io {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+            save::decode_ron(&data).map_err(|e| AutosaveError::Ron {
+                path: path.to_path_buf(),
+                source: e,
+            })
+        }
+        SaveCodec::Cbor => {
+            let bytes = fs::read(path).map_err(|e| AutosaveError::Io {
+                path: path.to_path_buf(),
+                source: e,
+            })?;
+            save::decode_cbor(&bytes).map_err(|e| AutosaveError::CborDecode {
+                path: path.to_path_buf(),
+                source: e,
+            })
+        }
+    }
+}
+
+fn encode_save(
+    save_game: &SaveGame,
+    codec: SaveCodec,
+    path: &Path,
+) -> Result<Vec<u8>, AutosaveError> {
+    match codec {
+        SaveCodec::Json => save::encode_json(save_game)
+            .map(|s| s.into_bytes())
+            .map_err(|e| AutosaveError::Json {
+                path: path.to_path_buf(),
+                source: e,
+            }),
+        SaveCodec::Ron => save::encode_ron(save_game)
+            .map(|s| s.into_bytes())
+            .map_err(|e| AutosaveError::Ron {
+                path: path.to_path_buf(),
+                source: e,
+            }),
+        SaveCodec::Cbor => save::encode_cbor(save_game).map_err(|e| AutosaveError::CborEncode {
+            path: path.to_path_buf(),
+            source: e,
+        }),
+    }
+}
+
+fn write_save_atomic(
+    path: &Path,
+    save_game: &SaveGame,
+    codec: SaveCodec,
+) -> Result<(), AutosaveError> {
+    let bytes = encode_save(save_game, codec, path)?;
+    write_bytes_atomic(path, &bytes)
+}
+
+fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<(), AutosaveError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).map_err(|e| AutosaveError::Io {
+        path: parent.to_path_buf(),
+        source: e,
+    })?;
+
+    let file_name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "autosave".to_string());
+    let tmp_path = path.with_file_name(format!("{file_name}.tmp"));
+    let backup_path = path.with_file_name(format!("{file_name}.bak"));
+
+    {
+        let mut f = fs::File::create(&tmp_path).map_err(|e| AutosaveError::Io {
+            path: tmp_path.clone(),
+            source: e,
+        })?;
+        f.write_all(bytes).map_err(|e| AutosaveError::Io {
+            path: tmp_path.clone(),
+            source: e,
+        })?;
+        f.sync_all().map_err(|e| AutosaveError::Io {
+            path: tmp_path.clone(),
+            source: e,
+        })?;
+    }
+
+    // Move the previous save out of the way (best-effort), preserving a rollback.
+    if path.exists() {
+        let _ = fs::remove_file(&backup_path);
+        fs::rename(path, &backup_path).map_err(|e| AutosaveError::Io {
+            path: backup_path.clone(),
+            source: e,
+        })?;
+    }
+
+    fs::rename(&tmp_path, path).map_err(|e| AutosaveError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    Ok(())
+}

--- a/crates/gc_core/src/autosave.rs
+++ b/crates/gc_core/src/autosave.rs
@@ -179,6 +179,19 @@ impl AutosaveManager {
 
         Ok(Some(path))
     }
+
+    /// Align internal cadence tracking to the world's current tick.
+    ///
+    /// This is useful when starting from a recovered save (non-zero tick count),
+    /// to avoid immediately writing another autosave on the next tick.
+    pub fn sync_last_saved_tick_from_world(&mut self, world: &World) -> Result<(), AutosaveError> {
+        let ticks = world
+            .get_resource::<Time>()
+            .map(|t| t.ticks)
+            .ok_or(AutosaveError::MissingTime)?;
+        self.last_saved_tick = ticks;
+        Ok(())
+    }
 }
 
 /// Compute the on-disk path for a slot.
@@ -209,7 +222,7 @@ pub fn recover_latest_autosave(
     dir: impl AsRef<Path>,
     config: &AutosaveConfig,
 ) -> Result<Option<RecoveredAutosave>, AutosaveError> {
-    if !config.enabled() {
+    if config.slots == 0 {
         return Ok(None);
     }
 

--- a/crates/gc_core/src/components.rs
+++ b/crates/gc_core/src/components.rs
@@ -40,7 +40,9 @@ pub struct VisionRadius(pub i32);
 /// Represents the lifecycle state of a designation
 /// Designations go through states to prevent duplicate processing and
 /// enable proper cleanup of completed or invalid designations
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash, Serialize, Deserialize,
+)]
 pub enum DesignationState {
     /// Active designation ready to be processed
     /// This is the initial state when a designation is created

--- a/crates/gc_core/src/lib.rs
+++ b/crates/gc_core/src/lib.rs
@@ -103,6 +103,7 @@ impl ActionLog {
 /// // Now you have access to Position, GameMap, JobBoard, etc.
 /// ```
 pub mod prelude {
+    pub use crate::autosave::*;
     pub use crate::bootstrap::*;
     pub use crate::components::*;
     pub use crate::designations::*;
@@ -121,6 +122,8 @@ pub mod prelude {
 // Public module declarations
 // Each module contains related functionality for specific simulation aspects
 
+/// Autosave and crash recovery helpers (rotating slots, recovery scanning)
+pub mod autosave;
 /// ECS components for entities, spatial data, and game state
 pub mod components;
 /// Player designation system for marking areas for mining, construction, etc.

--- a/crates/gc_core/src/save.rs
+++ b/crates/gc_core/src/save.rs
@@ -67,7 +67,7 @@ fn sort_entities_deterministically(entities: &mut [EntityData]) {
     });
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SaveGame {
     pub width: u32,
     pub height: u32,
@@ -88,7 +88,7 @@ fn default_tick_ms() -> u64 {
     100
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityData {
     pub name: Option<String>,
     pub pos: Option<(i32, i32)>,

--- a/crates/gc_core/src/save.rs
+++ b/crates/gc_core/src/save.rs
@@ -1,4 +1,8 @@
-use crate::components::{Carriable, Item, ItemType};
+use crate::components::{
+    AssignedJob, Carriable, Carrier, DesignationLifecycle, DesignationState, Goblin, Inventory,
+    Item, ItemType, Miner, Stockpile, VisionRadius, ZoneBounds,
+};
+use crate::designations::MineDesignation;
 use crate::systems;
 use crate::world::{GameMap, Name, Position, TileKind, Velocity};
 use bevy_ecs::prelude::*;
@@ -7,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Sort entity records in a stable, deterministic order.
 ///
-/// Ordering key: (name, pos, vel, item_type, carriable)
+/// Ordering key: (name, pos, vel, item_type, carriable, role flags, zone/designation info)
 fn sort_entities_deterministically(entities: &mut [EntityData]) {
     use std::cmp::Ordering;
     entities.sort_by(|a, b| {
@@ -27,7 +31,39 @@ fn sort_entities_deterministically(entities: &mut [EntityData]) {
         if item_ord != Ordering::Equal {
             return item_ord;
         }
-        a.carriable.cmp(&b.carriable)
+        let carriable_ord = a.carriable.cmp(&b.carriable);
+        if carriable_ord != Ordering::Equal {
+            return carriable_ord;
+        }
+        let goblin_ord = a.goblin.cmp(&b.goblin);
+        if goblin_ord != Ordering::Equal {
+            return goblin_ord;
+        }
+        let miner_ord = a.miner.cmp(&b.miner);
+        if miner_ord != Ordering::Equal {
+            return miner_ord;
+        }
+        let carrier_ord = a.carrier.cmp(&b.carrier);
+        if carrier_ord != Ordering::Equal {
+            return carrier_ord;
+        }
+        let stockpile_ord = a.stockpile.cmp(&b.stockpile);
+        if stockpile_ord != Ordering::Equal {
+            return stockpile_ord;
+        }
+        let stockpile_accepts_ord = a.stockpile_accepts.cmp(&b.stockpile_accepts);
+        if stockpile_accepts_ord != Ordering::Equal {
+            return stockpile_accepts_ord;
+        }
+        let bounds_ord = a.zone_bounds.cmp(&b.zone_bounds);
+        if bounds_ord != Ordering::Equal {
+            return bounds_ord;
+        }
+        let mine_desig_ord = a.mine_designation.cmp(&b.mine_designation);
+        if mine_desig_ord != Ordering::Equal {
+            return mine_desig_ord;
+        }
+        a.designation_state.cmp(&b.designation_state)
     });
 }
 
@@ -59,6 +95,41 @@ pub struct EntityData {
     pub vel: Option<(i32, i32)>,
     pub item_type: Option<ItemType>,
     pub carriable: bool,
+    /// Marker for goblin agents (optional; not currently used by core systems)
+    #[serde(default)]
+    pub goblin: bool,
+    /// Marker for miner agents (required for mining job execution)
+    #[serde(default)]
+    pub miner: bool,
+    /// Marker for carrier agents (required for hauling job execution)
+    #[serde(default)]
+    pub carrier: bool,
+    /// Marker for stockpile zone entities
+    #[serde(default)]
+    pub stockpile: bool,
+    /// Optional stockpile acceptance list (None = accepts all)
+    #[serde(default)]
+    pub stockpile_accepts: Option<Vec<ItemType>>,
+    /// Optional zone bounds for stockpiles and other rectangular zones
+    #[serde(default)]
+    pub zone_bounds: Option<ZoneBoundsData>,
+    /// Marker for mine designation entities
+    #[serde(default)]
+    pub mine_designation: bool,
+    /// Lifecycle state for designations (only meaningful when mine_designation=true)
+    #[serde(default)]
+    pub designation_state: Option<DesignationState>,
+}
+
+/// Serializable representation of `ZoneBounds` for save/load.
+///
+/// Stored as plain ints to avoid forcing serde derives on all ECS components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ZoneBoundsData {
+    pub min_x: i32,
+    pub min_y: i32,
+    pub max_x: i32,
+    pub max_y: i32,
 }
 
 pub fn save_world(world: &mut World) -> SaveGame {
@@ -75,14 +146,53 @@ pub fn save_world(world: &mut World) -> SaveGame {
         Option<&Velocity>,
         Option<&Item>,
         Option<&Carriable>,
+        Option<&Goblin>,
+        Option<&Miner>,
+        Option<&Carrier>,
+        Option<&Stockpile>,
+        Option<&ZoneBounds>,
+        Option<&MineDesignation>,
+        Option<&DesignationLifecycle>,
     )>();
-    for (name, pos, vel, item, carriable) in q.iter(world) {
+    for (
+        name,
+        pos,
+        vel,
+        item,
+        carriable,
+        goblin,
+        miner,
+        carrier,
+        stockpile,
+        bounds,
+        mine_desig,
+        lifecycle,
+    ) in q.iter(world)
+    {
+        let mine_designation = mine_desig.is_some();
         entities.push(EntityData {
             name: name.map(|n| n.0.clone()),
             pos: pos.map(|p| (p.0, p.1)),
             vel: vel.map(|v| (v.0, v.1)),
             item_type: item.map(|i| i.item_type),
             carriable: carriable.is_some(),
+            goblin: goblin.is_some(),
+            miner: miner.is_some(),
+            carrier: carrier.is_some(),
+            stockpile: stockpile.is_some(),
+            stockpile_accepts: stockpile.and_then(|s| s.accepts.clone()),
+            zone_bounds: bounds.map(|b| ZoneBoundsData {
+                min_x: b.min_x,
+                min_y: b.min_y,
+                max_x: b.max_x,
+                max_y: b.max_y,
+            }),
+            mine_designation,
+            designation_state: if mine_designation {
+                lifecycle.map(|l| l.0)
+            } else {
+                None
+            },
         });
     }
     // Deterministic ordering across codecs and runs
@@ -136,6 +246,41 @@ pub fn load_world(save: SaveGame, world: &mut World) {
         }
         if e.carriable {
             ec.insert(Carriable);
+        }
+        if e.goblin {
+            ec.insert(Goblin);
+        }
+        if e.miner {
+            // Minimal required components for job systems to "see" this entity
+            ec.insert((Miner, AssignedJob::default(), VisionRadius(8)));
+        }
+        if e.carrier {
+            // Minimal required components for hauling systems to "see" this entity
+            ec.insert((
+                Carrier,
+                Inventory::default(),
+                AssignedJob::default(),
+                VisionRadius(8),
+            ));
+        }
+        if e.stockpile {
+            ec.insert(Stockpile {
+                accepts: e.stockpile_accepts,
+            });
+        }
+        if let Some(bounds) = e.zone_bounds {
+            ec.insert(ZoneBounds::new(
+                bounds.min_x,
+                bounds.min_y,
+                bounds.max_x,
+                bounds.max_y,
+            ));
+        }
+        if e.mine_designation {
+            ec.insert(MineDesignation);
+            ec.insert(DesignationLifecycle(
+                e.designation_state.unwrap_or(DesignationState::Active),
+            ));
         }
     }
 }

--- a/crates/gc_core/tests/autosave_tests.rs
+++ b/crates/gc_core/tests/autosave_tests.rs
@@ -1,0 +1,141 @@
+use gc_core::autosave::*;
+use gc_core::bootstrap::{build_default_schedule, build_standard_world, WorldOptions};
+use gc_core::save;
+use std::fs;
+use std::path::PathBuf;
+
+fn temp_autosave_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "goblin-camp-autosave-test-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    fs::create_dir_all(&dir).expect("create temp autosave dir");
+    dir
+}
+
+#[test]
+fn autosave_manager_writes_rotating_slots() {
+    let dir = temp_autosave_dir();
+
+    let mut world = build_standard_world(
+        20,
+        10,
+        42,
+        WorldOptions {
+            populate_demo_scene: true,
+            tick_ms: 100,
+        },
+    );
+    let mut schedule = build_default_schedule();
+
+    let config = AutosaveConfig {
+        every_ticks: 2,
+        slots: 2,
+        codec: SaveCodec::Json,
+        base_name: "autosave".to_string(),
+    };
+    let mut mgr = AutosaveManager::new(&dir, config.clone()).expect("create autosave manager");
+
+    for _ in 0..5 {
+        schedule.run(&mut world);
+        let _ = mgr.maybe_autosave(&mut world).expect("autosave tick");
+    }
+
+    let slot0 = autosave_slot_path(&dir, "autosave", 0, SaveCodec::Json);
+    let slot1 = autosave_slot_path(&dir, "autosave", 1, SaveCodec::Json);
+    assert!(slot0.exists(), "slot0 should exist");
+    assert!(slot1.exists(), "slot1 should exist");
+
+    // Newest valid autosave should correspond to tick=4 (saved every 2 ticks).
+    let recovered = recover_latest_autosave(&dir, &config)
+        .expect("recover latest")
+        .expect("some autosave should exist");
+    assert_eq!(recovered.save.ticks, 4);
+
+    // Validate that core gameplay entities are captured by the save snapshot.
+    assert!(recovered.save.entities.iter().any(|e| e.miner));
+    assert!(recovered.save.entities.iter().any(|e| e.carrier));
+    assert!(recovered.save.entities.iter().any(|e| e.stockpile));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn recovery_uses_backup_when_primary_corrupt() {
+    let dir = temp_autosave_dir();
+
+    let config = AutosaveConfig {
+        every_ticks: 1,
+        slots: 2,
+        codec: SaveCodec::Json,
+        base_name: "autosave".to_string(),
+    };
+
+    // Create a valid save (tick=10) and write to slot 0.
+    let mut world = build_standard_world(3, 3, 42, WorldOptions::default());
+    world.resource_mut::<gc_core::systems::Time>().ticks = 10;
+    let save10 = save::save_world(&mut world);
+    let slot0 = autosave_slot_path(&dir, "autosave", 0, SaveCodec::Json);
+    fs::write(&slot0, save::encode_json(&save10).expect("encode json")).expect("write slot0");
+
+    // Slot 1 is corrupted, but its backup is valid and newer (tick=20).
+    let slot1 = autosave_slot_path(&dir, "autosave", 1, SaveCodec::Json);
+    fs::write(&slot1, "{not valid json").expect("write corrupt slot1");
+    world.resource_mut::<gc_core::systems::Time>().ticks = 20;
+    let save20 = save::save_world(&mut world);
+    let slot1_bak = autosave_slot_backup_path(&dir, "autosave", 1, SaveCodec::Json);
+    fs::write(&slot1_bak, save::encode_json(&save20).expect("encode json"))
+        .expect("write slot1 backup");
+
+    let recovered = recover_latest_autosave(&dir, &config)
+        .expect("recover latest")
+        .expect("some autosave should exist");
+    assert_eq!(recovered.save.ticks, 20);
+    assert_eq!(recovered.path, slot1_bak);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn golden_fixtures_load_and_recover() {
+    let dir = temp_autosave_dir();
+
+    let config = AutosaveConfig {
+        every_ticks: 1,
+        slots: 2,
+        codec: SaveCodec::Json,
+        base_name: "autosave".to_string(),
+    };
+
+    let good10: save::SaveGame =
+        save::decode_json(include_str!("fixtures/autosave/good-10.json")).expect("decode good10");
+    let good20: save::SaveGame =
+        save::decode_json(include_str!("fixtures/autosave/good-20.json")).expect("decode good20");
+
+    // Write fixtures into expected slot layout.
+    fs::write(
+        autosave_slot_path(&dir, "autosave", 0, SaveCodec::Json),
+        save::encode_json(&good10).expect("encode good10"),
+    )
+    .expect("write slot0");
+
+    fs::write(
+        autosave_slot_path(&dir, "autosave", 1, SaveCodec::Json),
+        include_str!("fixtures/autosave/corrupt.json"),
+    )
+    .expect("write corrupt slot1");
+
+    fs::write(
+        autosave_slot_backup_path(&dir, "autosave", 1, SaveCodec::Json),
+        save::encode_json(&good20).expect("encode good20"),
+    )
+    .expect("write slot1 backup");
+
+    let recovered = recover_latest_autosave(&dir, &config)
+        .expect("recover latest")
+        .expect("some autosave should exist");
+    assert_eq!(recovered.save.ticks, 20);
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/crates/gc_core/tests/fixtures/autosave/corrupt.json
+++ b/crates/gc_core/tests/fixtures/autosave/corrupt.json
@@ -1,0 +1,3 @@
+{"width": 3, "height":
+
+

--- a/crates/gc_core/tests/fixtures/autosave/good-10.json
+++ b/crates/gc_core/tests/fixtures/autosave/good-10.json
@@ -1,0 +1,97 @@
+{
+  "width": 3,
+  "height": 3,
+  "tiles": [
+    "Floor",
+    "Floor",
+    "Floor",
+    "Floor",
+    "Wall",
+    "Floor",
+    "Floor",
+    "Floor",
+    "Floor"
+  ],
+  "entities": [
+    {
+      "name": "Grak",
+      "pos": [1, 1],
+      "vel": [0, 0],
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": true,
+      "carrier": false,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": false,
+      "designation_state": null
+    },
+    {
+      "name": "Urok",
+      "pos": [1, 1],
+      "vel": [0, 0],
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": false,
+      "carrier": true,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": false,
+      "designation_state": null
+    },
+    {
+      "name": "Stockpile",
+      "pos": [2, 2],
+      "vel": null,
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": false,
+      "carrier": false,
+      "stockpile": true,
+      "stockpile_accepts": null,
+      "zone_bounds": { "min_x": 1, "min_y": 1, "max_x": 2, "max_y": 2 },
+      "mine_designation": false,
+      "designation_state": null
+    },
+    {
+      "name": null,
+      "pos": [0, 0],
+      "vel": null,
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": false,
+      "carrier": false,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": true,
+      "designation_state": "Active"
+    },
+    {
+      "name": "Stone",
+      "pos": [0, 1],
+      "vel": null,
+      "item_type": "Stone",
+      "carriable": true,
+      "goblin": false,
+      "miner": false,
+      "carrier": false,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": false,
+      "designation_state": null
+    }
+  ],
+  "tick_ms": 100,
+  "ticks": 10,
+  "master_seed": 42
+}
+
+

--- a/crates/gc_core/tests/fixtures/autosave/good-20.json
+++ b/crates/gc_core/tests/fixtures/autosave/good-20.json
@@ -1,0 +1,97 @@
+{
+  "width": 3,
+  "height": 3,
+  "tiles": [
+    "Floor",
+    "Floor",
+    "Floor",
+    "Floor",
+    "Wall",
+    "Floor",
+    "Floor",
+    "Floor",
+    "Floor"
+  ],
+  "entities": [
+    {
+      "name": "Grak",
+      "pos": [1, 1],
+      "vel": [0, 0],
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": true,
+      "carrier": false,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": false,
+      "designation_state": null
+    },
+    {
+      "name": "Urok",
+      "pos": [1, 1],
+      "vel": [0, 0],
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": false,
+      "carrier": true,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": false,
+      "designation_state": null
+    },
+    {
+      "name": "Stockpile",
+      "pos": [2, 2],
+      "vel": null,
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": false,
+      "carrier": false,
+      "stockpile": true,
+      "stockpile_accepts": null,
+      "zone_bounds": { "min_x": 1, "min_y": 1, "max_x": 2, "max_y": 2 },
+      "mine_designation": false,
+      "designation_state": null
+    },
+    {
+      "name": null,
+      "pos": [0, 0],
+      "vel": null,
+      "item_type": null,
+      "carriable": false,
+      "goblin": false,
+      "miner": false,
+      "carrier": false,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": true,
+      "designation_state": "Consumed"
+    },
+    {
+      "name": "Stone",
+      "pos": [0, 1],
+      "vel": null,
+      "item_type": "Stone",
+      "carriable": true,
+      "goblin": false,
+      "miner": false,
+      "carrier": false,
+      "stockpile": false,
+      "stockpile_accepts": null,
+      "zone_bounds": null,
+      "mine_designation": false,
+      "designation_state": null
+    }
+  ],
+  "tick_ms": 100,
+  "ticks": 20,
+  "master_seed": 42
+}
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ This directory contains the complete design documentation, architectural decisio
 
 #### 💾 **Data & Persistence**
 - **[Save/Load System](design/save_load.md)** - Serialization, persistence, and versioning
+- **[Autosave & Crash Recovery](design/autosave_crash_recovery.md)** - Rotating autosaves, recovery, and corruption handling
 - **[Data Structures](../crates/gc_core/src/components.rs)** - Core ECS components and data layout
 
 ---
@@ -53,6 +54,7 @@ docs/
 │   ├── designation_lifecycle.md #     Designation state management
 │   ├── mining_items_stockpiles.md #  Mining pipeline design
 │   ├── pathfinding.md         #     Pathfinding implementation
+│   ├── autosave_crash_recovery.md # Autosave and recovery design
 │   ├── save_load.md           #     Save/load system design
 │   ├── sim_loop.md            #     Simulation loop architecture
 │   └── worldgen.md            #     World generation design

--- a/docs/design/autosave_crash_recovery.md
+++ b/docs/design/autosave_crash_recovery.md
@@ -1,0 +1,72 @@
+# Autosave & Crash Recovery
+
+This document describes the autosave system used to periodically snapshot the simulation and recover after an unclean shutdown.
+
+## Goals
+
+- **Periodic autosaves** on a fixed cadence (configurable interval)
+- **Rotating slots** so recent history is preserved (configurable slot count)
+- **Crash detection + recovery prompt** in the CLI
+- **Corruption tolerance**: recover the newest valid save even if the latest slot is truncated/corrupt
+
+## Determinism
+
+Autosave cadence is based on **simulation ticks** (`systems::Time::ticks`), not wall-clock time.
+
+This keeps the simulation deterministic: the decision to autosave depends only on the tick counter.
+
+## File Layout
+
+Autosaves are stored in a directory (default: `autosaves/`).
+
+- **Primary slot**: `autosave-{slot}.{ext}`
+- **Per-slot backup**: `autosave-{slot}.{ext}.bak`
+- **Crash marker**: `autosave.lock`
+
+Where:
+
+- `{slot}` is the rotating slot index (0..N-1)
+- `{ext}` is one of `json`, `ron`, `cbor`
+
+## Atomic Writes and Backups
+
+Writing a slot uses a simple atomic pattern:
+
+1. Write `autosave-{slot}.{ext}.tmp`
+2. Rename existing `autosave-{slot}.{ext}` → `autosave-{slot}.{ext}.bak` (best-effort)
+3. Rename `.tmp` → the final slot path
+
+If a crash happens mid-write, recovery can fall back to `.bak`.
+
+## Recovery
+
+Recovery scans all configured slots and their `.bak` backups, decodes any valid saves, and picks the **newest** by `SaveGame.ticks`.
+
+This avoids relying on filesystem modification times (which can be inconsistent across platforms).
+
+## CLI Usage
+
+### Enable autosave during a demo run
+
+```bash
+cargo run -p gc_cli -- jobs --autosave-every 10 --autosave-slots 3 --autosave-dir autosaves
+```
+
+### Load the newest autosave before running a demo
+
+```bash
+cargo run -p gc_cli -- jobs --load-autosave --autosave-dir autosaves
+```
+
+### Crash recovery prompt
+
+If `autosave.lock` exists and the CLI is running interactively, `gc_cli` will prompt to recover the newest valid autosave.
+
+## Tests
+
+- **Golden fixtures** live under `crates/gc_core/tests/fixtures/autosave/`
+- **Recovery tests** validate:
+  - rotating slots write correctly
+  - recovery skips corrupted primaries and can recover from `.bak`
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Welcome to the Goblin Camp documentation! This site contains detailed informatio
   <li><a href="/design/needs_moods_traits">Needs, Moods, and Traits</a></li>
       <li><a href="/design/pathfinding">Pathfinding</a></li>
       <li><a href="/design/save_load">Save/Load System</a></li>
+      <li><a href="/design/autosave_crash_recovery">Autosave & Crash Recovery</a></li>
       <li><a href="/design/sim_loop">Simulation Loop</a></li>
       <li><a href="/design/worldgen">World Generation</a></li>
   <li><a href="/design/combat_mvp">Design: Combat MVP (simple injuries/death)</a></li>


### PR DESCRIPTION
## Summary
- Adds tick-based autosaves with rotating slots and per-slot .bak rollback for corruption/crash tolerance
- Adds recovery scanning (pick newest valid save by in-save tick counter)
- Wires autosave + recovery into gc_cli with flags and an interactive crash-recovery prompt
- Adds golden fixtures + recovery tests, and documents the system

## How to test
- ./dev.sh check
- ./dev.sh validate
- Manual:
  - cargo run -p gc_cli -- jobs --autosave-every 2 --autosave-slots 2 --autosave-dir autosaves
  - (optional) simulate an unclean exit, then rerun with: cargo run -p gc_cli -- jobs --load-autosave --autosave-dir autosaves

## Notes
- Autosave cadence is based on simulation ticks (Time::ticks), not wall-clock time

Fixes #214
Fixes #217
Closes #202

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tick-based rotating autosaves with recovery scanning and CLI flags/prompt, plus save schema updates, tests, and docs.
> 
> - **Core (`gc_core`)**
>   - **Autosave module** `gc_core::autosave` with `AutosaveManager`, `recover_latest_autosave`, `SaveCodec`; rotating slots, atomic writes with `.bak` rollback.
>   - **Save/Load**: Extend `SaveGame`/`EntityData` to persist `ticks`, `tick_ms`, `master_seed`, and components/markers (`Goblin`, `Miner`, `Carrier`, `Stockpile`, `ZoneBounds`, `MineDesignation`, `DesignationLifecycle`); deterministic entity sort; corresponding load logic.
>   - **Components**: `DesignationState` derives `Serialize`/`Deserialize` (and ordering traits).
> - **CLI (`gc_cli`)**
>   - New flags: `--autosave-every`, `--autosave-slots`, `--autosave-dir`, `--autosave-codec`, `--load-autosave`, `--no-recovery-prompt`.
>   - Session lock `autosave.lock`, interactive recovery prompt, load newest autosave on start; hook `AutosaveManager` into demo loop (e.g., Jobs); refactor demos to accept a provided `World`.
> - **Tests & Fixtures**
>   - Autosave recovery tests and golden fixtures (good/corrupt) validating slot rotation and `.bak` fallback.
> - **Docs**
>   - Add autosave/crash recovery design doc and update README/CHANGELOG references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fdfd88bf50333dbb081a2df9177f53dfae6af1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added autosave functionality with configurable periodic saves across rotating slots
  * Implemented crash recovery detection and interactive recovery prompt on startup after unclean shutdown
  * Support for multiple save formats (JSON, Ron, CBOR)
  * Added CLI flags to control autosave behavior: `--autosave-every`, `--autosave-slots`, `--autosave-dir`, `--autosave-codec`, `--load-autosave`

* **Documentation**
  * Added autosave and crash recovery design documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->